### PR TITLE
Fix deprecation warnings of yaml and upsample

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ This repository contains the source code of our paper:
 ## Inference
 
 ```bash
+# add VNL lib to python path
+export PATH=$HOME/DepthEstimation/VNL_Monocular_Depth_Prediction/lib/:$PATH
+
 # Run the inferece on NYUDV2 dataset
  python  ./tools/test_nyu_metric.py \
 		--dataroot    ./datasets/NYUDV2 \

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This repository contains the source code of our paper:
 
 ```bash
 # add VNL lib to python path
-export PATH=$HOME/DepthEstimation/VNL_Monocular_Depth_Prediction/lib/:$PATH
+export PATH=$HOME/VNL_Monocular_Depth_Prediction/lib/:$PATH
 
 # Run the inferece on NYUDV2 dataset
  python  ./tools/test_nyu_metric.py \

--- a/lib/core/config.py
+++ b/lib/core/config.py
@@ -123,7 +123,7 @@ def merge_cfg_from_file(train_args):
     cfg_filename = train_args.cfg_file
     cfg_file = os.path.join(__C.ROOT_DIR, cfg_filename + '.yaml')
     with open(cfg_file, 'r') as f:
-        yaml_cfg = AttrDict(yaml.load(f))
+        yaml_cfg = AttrDict(yaml.load(f, Loader=yaml.FullLoader))
     _merge_a_into_b(yaml_cfg, __C)
     __C.DATASET.DEPTH_MIN_LOG = np.log10(__C.DATASET.DEPTH_MIN)
     # Modify some configs

--- a/lib/models/lateral_net.py
+++ b/lib/models/lateral_net.py
@@ -148,7 +148,7 @@ class ASPP_block(nn.Module):
         x5 = self.globalpool_conv1x1(x5)
         x5 = self.globalpool_bn(x5)
         w, h = x1.size(2), x1.size(3)
-        x5 = F.upsample(input=x5, size=(w, h), mode='bilinear', align_corners=True)
+        x5 = F.interpolate(input=x5, size=(w, h), mode='bilinear', align_corners=True)
 
         out = torch.cat([x1, x2, x3, x4, x5], 1)
         return out
@@ -308,7 +308,7 @@ class fcn_last_block(nn.Module):
         self.ftb = FTB_block(dim_in, dim_out)
 
     def forward(self, input, backbone_stage_size):
-        out = F.upsample(input=input, size=(backbone_stage_size[4][0], backbone_stage_size[4][1]), mode='bilinear', align_corners=True)
+        out = F.interpolate(input=input, size=(backbone_stage_size[4][0], backbone_stage_size[4][1]), mode='bilinear', align_corners=True)
         out = self.ftb(out)
-        out = F.upsample(input=out, size=(backbone_stage_size[5][0], backbone_stage_size[5][1]), mode='bilinear', align_corners=True)
+        out = F.interpolate(input=out, size=(backbone_stage_size[5][0], backbone_stage_size[5][1]), mode='bilinear', align_corners=True)
         return out


### PR DESCRIPTION
* Replaced deprecated `F.upsample` with `F.interpolate`.
* Fixed [deprecation warning](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) for `yaml.load()`.
* Added instruction to add VNL lib to `PYTHONPATH`.
